### PR TITLE
Update dependency constraints for Python 3.9–3.13

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,4 @@
-numpy>=1.19
-scipy>=1.5
-numba>=0.50
-numexpr>=2.7
-pyfftw>=0.12
-nbsphinx
-ipython
-pygments>=2.4
+-c ../requirements-constraints.txt
+nbsphinx>=0.9.4
+ipython>=8.12
+pygments>=2.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,15 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "numpy>=1.19",
-  "scipy>=1.5",
-  "numba>=0.50",
-  "pyfftw>=0.12",
-  "numexpr>=2.7",
+  "numpy>=1.26.4,<2.0; python_version<'3.13'",
+  "numpy>=2.1.0; python_version>='3.13'",
+  "scipy>=1.10.1,<1.11; python_version<'3.10'",
+  "scipy>=1.11.4,<1.14; python_version>='3.10' and python_version<'3.13'",
+  "scipy>=1.14.0; python_version>='3.13'",
+  "numba>=0.59.1; python_version<'3.12'",
+  "numba>=0.60.0; python_version>='3.12'",
+  "pyfftw>=0.13.1",
+  "numexpr>=2.8.4",
 ]
 
 [project.urls]

--- a/requirements-constraints.txt
+++ b/requirements-constraints.txt
@@ -1,0 +1,10 @@
+# Base dependency constraints aligned with pyproject.toml
+numpy>=1.26.4,<2.0; python_version<'3.13'
+numpy>=2.1.0; python_version>='3.13'
+scipy>=1.10.1,<1.11; python_version<'3.10'
+scipy>=1.11.4,<1.14; python_version>='3.10' and python_version<'3.13'
+scipy>=1.14.0; python_version>='3.13'
+numba>=0.59.1; python_version<'3.12'
+numba>=0.60.0; python_version>='3.12'
+pyfftw>=0.13.1
+numexpr>=2.8.4


### PR DESCRIPTION
## Summary
- raise core scientific dependencies and add Python-version markers to cover 3.9 through 3.13
- add a shared constraints file and update documentation requirements to reference it

## Testing
- PYTHONPATH=. pytest
- pip install -e . -c requirements-constraints.txt *(fails in CI environment: cannot reach package index)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958283ba8788327bcd0bef55332c6d7)