### PR TITLE
v2 core/API scaffold with legacy adapter and NumPy backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,34 @@
 - speed of the [FFTW](https://pypi.org/project/pyFFTW/), [BLAS](https://www.netlib.org/blas/) and [numexpr](https://numexpr.readthedocs.io/en/latest/) libraries with multithreading
 - crucial functions are just-in-time compiled with [numba](https://numba.readthedocs.io/en/stable/)
 
+### v2 API Quickstart
+
+```python
+import pytalises as pt
+
+grid = pt.Grid(shape=(256,), extent=((-4, 4),))
+psi = pt.Wavefunction(
+    initial=["exp(-x**2)", "0"],
+    grid=grid,
+)
+
+V = pt.HermitianPotential.from_lower_triangular([
+    "0",
+    "Omega*cos(t)",
+    "Delta",
+])
+
+psi.propagate(
+    potential=V,
+    steps=1000,
+    dt=1e-6,
+    variables={"Omega": 2.0, "Delta": 1.0},
+    options=pt.PropagationOptions(threads=4),
+)
+```
+
+For migration details from the pre-v2 API, see `docs/source/v2_migration.rst`.
+
 ### Documentation
 Read the [documentation](https://pytalises.readthedocs.io/en/latest/) to learn more about pytalises' capabilities.
 The documentation features many examples, among others

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,7 @@ Welcome to pytalises's documentation!
    examples
    additional_examples
    notes
+   v2_migration
    pytalises.rst
 
 

--- a/docs/source/pytalises.rst
+++ b/docs/source/pytalises.rst
@@ -11,6 +11,46 @@ API / Code Reference
 Submodules
 ------------------
 
+pytalises.backends module
+-----------------------------------
+
+.. automodule:: pytalises.backends
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pytalises.exceptions module
+-----------------------------------
+
+.. automodule:: pytalises.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pytalises.grid module
+-----------------------------------
+
+.. automodule:: pytalises.grid
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pytalises.options module
+-----------------------------------
+
+.. automodule:: pytalises.options
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pytalises.potentials module
+-----------------------------------
+
+.. automodule:: pytalises.potentials
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 pytalises.wavefunction module
 -----------------------------------
 
@@ -23,6 +63,14 @@ pytalises.propagator module
 -----------------------------------
 
 .. automodule:: pytalises.propagator
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pytalises.legacy module
+-----------------------------------
+
+.. automodule:: pytalises.legacy
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/v2_migration.rst
+++ b/docs/source/v2_migration.rst
@@ -1,0 +1,77 @@
+V1 to V2 Migration Guide
+========================
+
+pyTALISES v2 introduces a cleaner public API around explicit grids,
+structured potentials, and consolidated runtime options.
+
+Quick mapping
+-------------
+
+- ``number_of_grid_points`` + ``spatial_ext`` -> :class:`pytalises.Grid`
+- ``diag=True/False`` + string lists ->
+  :class:`pytalises.DiagonalPotential` / :class:`pytalises.HermitianPotential`
+- ``num_time_steps`` -> ``steps``
+- ``delta_t`` -> ``dt``
+- ``num_of_threads`` / ``FFTWflags`` -> :class:`pytalises.PropagationOptions`
+
+Example (before)
+----------------
+
+.. code-block:: python
+
+   import pytalises as pt
+
+   psi = pt.Wavefunction(
+       ["exp(-x**2)", "0"],
+       (256,),
+       (-4, 4),
+       variables={"x0": 0},
+   )
+
+   psi.propagate(
+       potential=["V0*x**2", "Omega*cos(t)", "V1*x**2"],
+       num_time_steps=1000,
+       delta_t=1e-6,
+       diag=False,
+       variables={"V0": 1.0, "V1": 1.0, "Omega": 2.0},
+   )
+
+Example (after)
+---------------
+
+.. code-block:: python
+
+   import pytalises as pt
+
+   grid = pt.Grid(shape=(256,), extent=((-4, 4),))
+   psi = pt.Wavefunction(
+       initial=["exp(-x**2)", "0"],
+       grid=grid,
+       variables={"x0": 0},
+   )
+
+   V = pt.HermitianPotential.from_lower_triangular(
+       ["V0*x**2", "Omega*cos(t)", "V1*x**2"]
+   )
+
+   psi.propagate(
+       potential=V,
+       steps=1000,
+       dt=1e-6,
+       variables={"V0": 1.0, "V1": 1.0, "Omega": 2.0},
+       options=pt.PropagationOptions(threads=4),
+   )
+
+Legacy adapter
+--------------
+
+A temporary compatibility adapter is available as ``pytalises.legacy``.
+
+.. code-block:: python
+
+   import pytalises as pt
+
+   psi = pt.legacy.Wavefunction("exp(-x**2)", (256,), (-4, 4))
+   psi.freely_propagate(num_time_steps=100, delta_t=1e-4)
+
+Using ``pytalises.legacy`` emits ``DeprecationWarning`` and will be removed in a future release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,4 +60,4 @@ zip-safe = false
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["pytalises"]
+include = ["pytalises", "pytalises.*"]

--- a/pytalises/__init__.py
+++ b/pytalises/__init__.py
@@ -1,2 +1,14 @@
+from .backends import get_backend, register_backend, set_default_backend  # noqa
+from .exceptions import (  # noqa
+    BackendError,
+    GridMismatchError,
+    PyTalisesError,
+    SerializationError,
+    ValidationError,
+)
+from .grid import Grid  # noqa
+from .options import PropagationOptions  # noqa
+from .potentials import DiagonalPotential, HermitianPotential  # noqa
 from .wavefunction import Wavefunction  # noqa
 from .propagator import Propagator, propagate, freely_propagate  # noqa
+from . import legacy  # noqa

--- a/pytalises/backends/__init__.py
+++ b/pytalises/backends/__init__.py
@@ -1,0 +1,49 @@
+"""Backend registry and auto-selection."""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from .base import Backend
+from .numpy_backend import NumpyBackend
+
+_BACKENDS = {
+    "numpy": NumpyBackend,
+}
+
+_default_backend: Optional[Backend] = None
+
+
+def register_backend(name: str, backend_class):
+    """Register a backend class under ``name``."""
+    _BACKENDS[name] = backend_class
+
+
+def _auto_detect_backend() -> str:
+    # Future: GPU detection for CuPy/JAX backends.
+    return "numpy"
+
+
+def get_backend(name: Union[str, Backend, None] = None, **kwargs) -> Backend:
+    """Return backend instance by name or pass-through existing instance."""
+    global _default_backend
+
+    if isinstance(name, Backend):
+        return name
+
+    if name is None or name == "auto":
+        if _default_backend is not None and name is None:
+            return _default_backend
+        name = _auto_detect_backend()
+
+    if name not in _BACKENDS:
+        available = sorted(_BACKENDS.keys())
+        raise ValueError(f"Unknown backend '{name}'. Available: {available}")
+
+    return _BACKENDS[name](**kwargs)
+
+
+def set_default_backend(backend: Union[str, Backend], **kwargs) -> None:
+    """Set global default backend instance."""
+    global _default_backend
+    _default_backend = get_backend(backend, **kwargs)

--- a/pytalises/backends/base.py
+++ b/pytalises/backends/base.py
@@ -1,0 +1,98 @@
+"""Backend abstraction interfaces for pyTALISES."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Tuple
+
+
+class FFTPlan(ABC):
+    """Abstract FFT plan interface."""
+
+    @abstractmethod
+    def forward(self) -> None:
+        """Execute forward FFT in-place."""
+
+    @abstractmethod
+    def backward(self) -> None:
+        """Execute backward FFT in-place."""
+
+
+class Backend(ABC):
+    """Abstract backend interface."""
+
+    name: str
+
+    @abstractmethod
+    def zeros(self, shape: Tuple[int, ...], dtype: Any = "complex128") -> Any:
+        """Create zero-filled array."""
+
+    @abstractmethod
+    def empty_aligned(self, shape: Tuple[int, ...], dtype: Any = "complex128") -> Any:
+        """Create uninitialized aligned array."""
+
+    @abstractmethod
+    def asarray(self, data: Any, dtype: Any = None) -> Any:
+        """Convert data to backend-native array."""
+
+    @abstractmethod
+    def create_fft_plan(
+        self,
+        array: Any,
+        axes: Tuple[int, ...],
+        num_threads: int = 1,
+        flags: tuple[str, ...] = ("FFTW_ESTIMATE", "FFTW_DESTROY_INPUT"),
+    ) -> FFTPlan:
+        """Create forward/backward FFT plan for array."""
+
+    @abstractmethod
+    def exp(self, x: Any) -> Any:
+        """Element-wise exponential."""
+
+    @abstractmethod
+    def einsum(self, subscripts: str, *operands: Any, out: Any = None) -> Any:
+        """Einstein summation."""
+
+    @abstractmethod
+    def evaluate(self, expr: str, local_dict: dict, global_dict: dict | None = None) -> Any:
+        """Evaluate expression with backend expression engine."""
+
+    @abstractmethod
+    def eigh(self, matrices: Any) -> tuple[Any, Any]:
+        """Batched eigendecomposition of Hermitian matrices."""
+
+    @abstractmethod
+    def meshgrid(self, *arrays: Any, indexing: str = "ij") -> list[Any]:
+        """Create meshgrid arrays."""
+
+    @abstractmethod
+    def linspace(self, start: float, stop: float, num: int) -> Any:
+        """Evenly spaced samples."""
+
+    @abstractmethod
+    def fftfreq(self, n: int) -> Any:
+        """FFT sample frequencies."""
+
+    @abstractmethod
+    def sum(self, x: Any, axis: Any = None) -> Any:
+        """Sum reduction."""
+
+    @abstractmethod
+    def abs(self, x: Any) -> Any:
+        """Absolute value."""
+
+    @abstractmethod
+    def sqrt(self, x: Any) -> Any:
+        """Square root."""
+
+    @abstractmethod
+    def conjugate(self, x: Any) -> Any:
+        """Complex conjugate."""
+
+    @abstractmethod
+    def power(self, x: Any, n: Any) -> Any:
+        """Element-wise power."""
+
+    @abstractmethod
+    def set_num_threads(self, n: int) -> None:
+        """Configure backend threading where relevant."""

--- a/pytalises/backends/numpy_backend.py
+++ b/pytalises/backends/numpy_backend.py
@@ -1,0 +1,139 @@
+"""NumPy backend implementation for pyTALISES."""
+
+from __future__ import annotations
+
+import numexpr as ne
+from numba import jit, prange, set_num_threads
+import numpy as np
+from numpy.linalg import eigh
+import pyfftw
+
+from .base import Backend, FFTPlan
+
+
+class NumpyFFTPlan(FFTPlan):
+    """pyFFTW-based FFT plan wrapper."""
+
+    def __init__(
+        self,
+        array,
+        axes,
+        num_threads=1,
+        flags=("FFTW_ESTIMATE", "FFTW_DESTROY_INPUT"),
+    ):
+        self._forward = pyfftw.FFTW(
+            array,
+            array,
+            axes=axes,
+            direction="FFTW_FORWARD",
+            threads=num_threads,
+            flags=flags,
+        )
+        self._backward = pyfftw.FFTW(
+            array,
+            array,
+            axes=axes,
+            direction="FFTW_BACKWARD",
+            threads=num_threads,
+            flags=flags,
+        )
+
+    def forward(self) -> None:
+        self._forward()
+
+    def backward(self) -> None:
+        self._backward()
+
+
+class NumpyBackend(Backend):
+    """NumPy/NumExpr/pyFFTW backend preserving current behavior."""
+
+    name = "numpy"
+
+    def __init__(self, num_threads: int = 1):
+        self.num_threads = num_threads
+        self.set_num_threads(num_threads)
+
+    def set_num_threads(self, n: int) -> None:
+        self.num_threads = n
+        set_num_threads(n)
+        ne.set_num_threads(n)
+
+    def zeros(self, shape, dtype="complex128"):
+        return np.zeros(shape, dtype=dtype, order="C")
+
+    def empty_aligned(self, shape, dtype="complex128"):
+        return pyfftw.empty_aligned(shape, dtype=dtype, order="C")
+
+    def asarray(self, data, dtype=None):
+        return np.asarray(data, dtype=dtype)
+
+    def create_fft_plan(
+        self,
+        array,
+        axes,
+        num_threads=1,
+        flags=("FFTW_ESTIMATE", "FFTW_DESTROY_INPUT"),
+    ):
+        pyfftw.config.NUM_THREADS = num_threads
+        return NumpyFFTPlan(array, axes, num_threads, flags)
+
+    def exp(self, x):
+        return np.exp(x)
+
+    def einsum(self, subscripts, *operands, out=None):
+        return np.einsum(
+            subscripts,
+            *operands,
+            out=out,
+            optimize="optimal",
+            order="C",
+        )
+
+    def evaluate(self, expr, local_dict, global_dict=None):
+        return ne.evaluate(
+            expr,
+            local_dict=local_dict,
+            global_dict=global_dict or {},
+            order="C",
+        )
+
+    def eigh(self, matrices):
+        eigvals = np.zeros(matrices.shape[:-1], order="C", dtype="complex128")
+        _batched_eigh_numba(matrices, eigvals)
+        return eigvals, matrices
+
+    def meshgrid(self, *arrays, indexing="ij"):
+        return np.meshgrid(*arrays, indexing=indexing)
+
+    def linspace(self, start, stop, num):
+        return np.linspace(start, stop, num)
+
+    def fftfreq(self, n):
+        return np.fft.fftfreq(n)
+
+    def sum(self, x, axis=None):
+        return np.sum(x, axis=axis)
+
+    def abs(self, x):
+        return np.abs(x)
+
+    def sqrt(self, x):
+        return np.sqrt(x)
+
+    def conjugate(self, x):
+        return np.conjugate(x)
+
+    def power(self, x, n):
+        return np.power(x, n)
+
+
+@jit(nopython=True, parallel=True, nogil=True, fastmath=True)
+def _batched_eigh_numba(matrices, eigvals):
+    nX, nY, nZ = matrices.shape[:3]
+    for i in prange(nX):
+        for j in prange(nY):
+            for k in prange(nZ):
+                eigvals[i, j, k, :], matrices[i, j, k, :, :] = eigh(
+                    matrices[i, j, k, :, :]
+                )

--- a/pytalises/exceptions.py
+++ b/pytalises/exceptions.py
@@ -1,0 +1,21 @@
+"""Public exceptions for pyTALISES."""
+
+
+class PyTalisesError(Exception):
+    """Base exception for all pyTALISES errors."""
+
+
+class BackendError(PyTalisesError):
+    """Backend operation failed."""
+
+
+class GridMismatchError(PyTalisesError):
+    """Wavefunction and potential have incompatible grids."""
+
+
+class ValidationError(PyTalisesError):
+    """Invalid user input."""
+
+
+class SerializationError(PyTalisesError):
+    """Failed to save or load wavefunction."""

--- a/pytalises/grid.py
+++ b/pytalises/grid.py
@@ -1,0 +1,48 @@
+"""Grid definition for pyTALISES v2."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Grid:
+    """Explicit spatial grid definition.
+
+    Parameters
+    ----------
+    shape:
+        Number of points per external dimension (1D-3D).
+    extent:
+        Spatial bounds per external dimension as ``(min, max)`` tuples.
+    """
+
+    shape: tuple[int, ...]
+    extent: tuple[tuple[float, float], ...]
+
+    def __post_init__(self) -> None:
+        if not (1 <= len(self.shape) <= 3):
+            raise ValueError("Grid supports 1 to 3 external dimensions.")
+        if len(self.extent) != len(self.shape):
+            raise ValueError("Grid.extent must have same length as Grid.shape.")
+        for n in self.shape:
+            if not isinstance(n, int) or n <= 0:
+                raise ValueError("Grid.shape must contain positive integers.")
+        for lo, hi in self.extent:
+            if hi < lo:
+                raise ValueError("Each extent tuple must satisfy max >= min.")
+
+    @property
+    def ndim(self) -> int:
+        """Number of external dimensions."""
+        return len(self.shape)
+
+    @property
+    def padded_shape(self) -> tuple[int, int, int]:
+        """Shape padded to internal 3D representation."""
+        return self.shape + (1,) * (3 - self.ndim)
+
+    @property
+    def padded_extent(self) -> tuple[tuple[float, float], tuple[float, float], tuple[float, float]]:
+        """Extent padded to internal 3D representation."""
+        return self.extent + ((0.0, 0.0),) * (3 - self.ndim)

--- a/pytalises/legacy.py
+++ b/pytalises/legacy.py
@@ -1,0 +1,277 @@
+"""v1 compatibility layer for pyTALISES.
+
+This module preserves the pre-v2 call signatures for one migration cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+import warnings
+
+import numpy as np
+
+from pytalises.grid import Grid
+from pytalises.options import PropagationOptions
+from pytalises.potentials import (
+    BasePotential,
+    DiagonalPotential,
+    HermitianPotential,
+)
+from pytalises.propagator import Propagator as _Propagator
+from pytalises.propagator import freely_propagate as _freely_propagate
+from pytalises.propagator import propagate as _propagate
+from pytalises.wavefunction import Wavefunction as _Wavefunction
+
+
+_LEGACY_MSG = (
+    "pytalises.legacy provides compatibility with the pre-v2 API and will be "
+    "removed in a future release. Please migrate to the v2 API "
+    "(Grid, structured potentials, steps/dt, PropagationOptions)."
+)
+
+
+def _warn_legacy() -> None:
+    warnings.warn(_LEGACY_MSG, DeprecationWarning, stacklevel=3)
+
+
+def _normalize_grid(
+    number_of_grid_points: tuple[int, ...] | int,
+    spatial_ext: list[tuple[float, float]] | tuple[float, float],
+) -> Grid:
+    if isinstance(number_of_grid_points, int):
+        number_of_grid_points = (number_of_grid_points,)
+    shape_input = tuple(number_of_grid_points)
+
+    if isinstance(spatial_ext, tuple) and len(spatial_ext) == 2 and all(
+        isinstance(x, (float, int)) for x in spatial_ext
+    ):
+        ext_input = [tuple(float(v) for v in spatial_ext)]
+    else:
+        ext_input = [tuple(float(v) for v in pair) for pair in spatial_ext]  # type: ignore[arg-type]
+
+    active_indices = [i for i, n in enumerate(shape_input) if n > 1]
+    if not active_indices:
+        active_indices = [0]
+        if not shape_input:
+            shape_input = (1,)
+
+    active_shape = tuple(shape_input[i] for i in active_indices)
+
+    if len(ext_input) == len(shape_input):
+        active_extent = tuple(ext_input[i] for i in active_indices)
+    elif len(ext_input) == len(active_shape):
+        active_extent = tuple(ext_input)
+    else:
+        raise ValueError(
+            "spatial_ext must match either full dimensionality of number_of_grid_points "
+            "or only the active (n>1) dimensions."
+        )
+
+    return Grid(shape=active_shape, extent=active_extent)
+
+
+def _to_structured_potential(
+    potential: BasePotential | str | list[str],
+    *,
+    diag: bool,
+    num_states: int,
+) -> BasePotential:
+    if isinstance(potential, BasePotential):
+        return potential
+
+    if isinstance(potential, str):
+        exprs = [potential]
+    else:
+        exprs = list(potential)
+
+    if diag:
+        return DiagonalPotential(exprs)
+    return HermitianPotential.from_lower_triangular(exprs, num_states=num_states)
+
+
+class Wavefunction(_Wavefunction):
+    """Legacy Wavefunction signature wrapper."""
+
+    def __init__(
+        self,
+        psi: str | list[str],
+        number_of_grid_points: tuple[int, ...] | int,
+        spatial_ext: list[tuple[float, float]] | tuple[float, float],
+        t0: float = 0.0,
+        m: float = 1.054571817e-34,
+        variables: dict[str, Any] | None = None,
+        normalize_const: float | None = None,
+    ) -> None:
+        _warn_legacy()
+        grid = _normalize_grid(number_of_grid_points, spatial_ext)
+        super().__init__(
+            initial=psi,
+            grid=grid,
+            t0=t0,
+            m=m,
+            variables=variables,
+            normalize_const=normalize_const,
+        )
+
+    @property
+    def r(self):  # type: ignore[override]
+        """Legacy behavior: array for 1D, list with padded axes otherwise."""
+        if self.num_ext_dim == 1:
+            return super().r[0]
+        return self._r
+
+    @property
+    def k(self):  # type: ignore[override]
+        """Legacy behavior: array for 1D, list with padded axes otherwise."""
+        if self.num_ext_dim == 1:
+            return super().k[0]
+        return self._k
+
+    @property
+    def amp(self):  # type: ignore[override]
+        """Legacy behavior: squeezed amplitude view."""
+        return np.squeeze(super().amp)
+
+    def freely_propagate(
+        self,
+        num_time_steps: int,
+        delta_t: float,
+        num_of_threads: int = 1,
+        FFTWflags: tuple[str, ...] = (
+            "FFTW_ESTIMATE",
+            "FFTW_DESTROY_INPUT",
+        ),
+    ) -> None:
+        options = PropagationOptions(threads=num_of_threads, fftw_flags=FFTWflags)
+        super().freely_propagate(steps=num_time_steps, dt=delta_t, options=options)
+
+    def propagate(
+        self,
+        potential: BasePotential | str | list[str],
+        num_time_steps: int,
+        delta_t: float,
+        **kwargs: Any,
+    ) -> None:
+        variables = kwargs.get("variables")
+        diag = kwargs.get("diag", False)
+        num_of_threads = kwargs.get("num_of_threads", 1)
+        FFTWflags = kwargs.get(
+            "FFTWflags",
+            (
+                "FFTW_ESTIMATE",
+                "FFTW_DESTROY_INPUT",
+            ),
+        )
+
+        options = PropagationOptions(threads=num_of_threads, fftw_flags=FFTWflags)
+        structured = _to_structured_potential(
+            potential,
+            diag=diag,
+            num_states=self.num_int_dim,
+        )
+        super().propagate(
+            potential=structured,
+            steps=num_time_steps,
+            dt=delta_t,
+            variables=variables,
+            options=options,
+        )
+
+
+class Propagator:
+    """Legacy Propagator signature wrapper."""
+
+    Potential = _Propagator.Potential
+
+    def __init__(
+        self,
+        psi: _Wavefunction,
+        potential: BasePotential | str | list[str],
+        variables: dict[str, Any] | None = None,
+        diag: bool = False,
+        num_of_threads: int = 1,
+        FFTWflags: tuple[str, ...] = (
+            "FFTW_ESTIMATE",
+            "FFTW_DESTROY_INPUT",
+        ),
+    ) -> None:
+        _warn_legacy()
+        options = PropagationOptions(threads=num_of_threads, fftw_flags=FFTWflags)
+        structured = _to_structured_potential(
+            potential,
+            diag=diag,
+            num_states=psi.num_int_dim,
+        )
+        self._inner = _Propagator(
+            psi,
+            structured,
+            variables=variables,
+            options=options,
+        )
+        self.psi = self._inner.psi
+        self.v = self._inner.v
+
+    def potential_prop(self, delta_t: float) -> None:
+        self._inner.potential_prop(delta_t)
+
+    def kinetic_prop(self, delta_t: float) -> None:
+        self._inner.kinetic_prop(delta_t)
+
+    def __getattr__(self, name: str):
+        return getattr(self._inner, name)
+
+
+def propagate(
+    psi: _Wavefunction,
+    potential: BasePotential | str | list[str],
+    num_time_steps: int,
+    delta_t: float,
+    **kwargs: Any,
+) -> None:
+    """Legacy module-level propagate wrapper."""
+    _warn_legacy()
+    variables = kwargs.get("variables")
+    diag = kwargs.get("diag", False)
+    num_of_threads = kwargs.get("num_of_threads", 1)
+    FFTWflags = kwargs.get(
+        "FFTWflags",
+        (
+            "FFTW_ESTIMATE",
+            "FFTW_DESTROY_INPUT",
+        ),
+    )
+    options = PropagationOptions(threads=num_of_threads, fftw_flags=FFTWflags)
+    structured = _to_structured_potential(
+        potential,
+        diag=diag,
+        num_states=psi.num_int_dim,
+    )
+    _propagate(
+        psi,
+        structured,
+        num_time_steps,
+        delta_t,
+        variables=variables,
+        options=options,
+    )
+
+
+def freely_propagate(
+    psi: _Wavefunction,
+    num_time_steps: int,
+    delta_t: float,
+    num_of_threads: int = 1,
+    FFTWflags: tuple[str, ...] = (
+        "FFTW_ESTIMATE",
+        "FFTW_DESTROY_INPUT",
+    ),
+) -> None:
+    """Legacy module-level free propagation wrapper."""
+    _warn_legacy()
+    options = PropagationOptions(threads=num_of_threads, fftw_flags=FFTWflags)
+    _freely_propagate(
+        psi,
+        num_time_steps,
+        delta_t,
+        options=options,
+    )

--- a/pytalises/options.py
+++ b/pytalises/options.py
@@ -1,0 +1,29 @@
+"""Runtime propagation options for pyTALISES v2."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PropagationOptions:
+    """Runtime configuration for propagation.
+
+    Notes
+    -----
+    ``backend`` and ``dtype`` are part of the v2 public surface and may be
+    ignored by the current NumPy backend implementation until additional
+    backends are integrated.
+    """
+
+    backend: str = "auto"
+    dtype: str = "complex128"
+    threads: int = 1
+    fftw_flags: tuple[str, ...] = (
+        "FFTW_ESTIMATE",
+        "FFTW_DESTROY_INPUT",
+    )
+
+    def __post_init__(self) -> None:
+        if self.threads < 1:
+            raise ValueError("PropagationOptions.threads must be >= 1")

--- a/pytalises/potentials.py
+++ b/pytalises/potentials.py
@@ -1,0 +1,118 @@
+"""Structured potential definitions for pyTALISES v2."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class PotentialSpec:
+    """Internal normalized potential representation."""
+
+    expressions: tuple[str, ...]
+    diag: bool
+
+
+class BasePotential:
+    """Base class for public potential specifications."""
+
+    def to_spec(self, num_states: int) -> PotentialSpec:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class DiagonalPotential(BasePotential):
+    """Diagonal potential with one expression per internal state."""
+
+    expressions: tuple[str, ...]
+
+    def __init__(self, expressions: str | Sequence[str]):
+        if isinstance(expressions, str):
+            expressions = (expressions,)
+        object.__setattr__(self, "expressions", tuple(expressions))
+
+    def to_spec(self, num_states: int) -> PotentialSpec:
+        if len(self.expressions) != num_states:
+            raise ValueError(
+                "DiagonalPotential must contain exactly one expression per internal state. "
+                f"Expected {num_states}, got {len(self.expressions)}."
+            )
+        return PotentialSpec(expressions=self.expressions, diag=True)
+
+
+@dataclass(frozen=True)
+class HermitianPotential(BasePotential):
+    """Hermitian potential specified through lower-triangular elements."""
+
+    lower_triangular: tuple[str, ...]
+
+    def __init__(self, lower_triangular: Sequence[str]):
+        object.__setattr__(self, "lower_triangular", tuple(lower_triangular))
+
+    @property
+    def num_states(self) -> int:
+        num_v = len(self.lower_triangular)
+        n = 0.5 * (math.sqrt(8 * num_v + 1) - 1)
+        if not float(n).is_integer():
+            raise ValueError(
+                "Number of lower-triangular elements is invalid for a Hermitian matrix."
+            )
+        return int(n)
+
+    @classmethod
+    def from_lower_triangular(
+        cls, lower_triangular: Sequence[str], num_states: int | None = None
+    ) -> "HermitianPotential":
+        pot = cls(lower_triangular)
+        if num_states is not None and pot.num_states != num_states:
+            raise ValueError(
+                f"Lower triangular data defines {pot.num_states} states, expected {num_states}."
+            )
+        return pot
+
+    @classmethod
+    def from_matrix(cls, matrix: Sequence[Sequence[str]]) -> "HermitianPotential":
+        n = len(matrix)
+        if n == 0:
+            raise ValueError("Potential matrix must not be empty.")
+        if any(len(row) != n for row in matrix):
+            raise ValueError("Potential matrix must be square.")
+
+        lower: list[str] = []
+        for i in range(n):
+            for j in range(i + 1):
+                if i == j:
+                    lower.append(matrix[i][j])
+                    continue
+                lij = matrix[i][j]
+                uji = matrix[j][i]
+                if lij is None and uji is None:
+                    raise ValueError(
+                        f"Off-diagonal element ({i},{j})/( {j},{i}) must be provided."
+                    )
+                if lij is None:
+                    lower.append(uji)
+                elif uji is None:
+                    lower.append(lij)
+                elif lij == uji:
+                    lower.append(lij)
+                else:
+                    raise ValueError(
+                        "from_matrix currently expects symmetric symbolic entries for off-diagonal terms. "
+                        f"Got ({i},{j})='{lij}' and ({j},{i})='{uji}'."
+                    )
+        return cls(tuple(lower))
+
+    def to_spec(self, num_states: int) -> PotentialSpec:
+        if self.num_states != num_states:
+            raise ValueError(
+                f"HermitianPotential defines {self.num_states} states but wavefunction has {num_states}."
+            )
+        return PotentialSpec(expressions=self.lower_triangular, diag=False)
+
+
+def zero_potential(num_states: int) -> DiagonalPotential:
+    """Return a diagonal zero-potential for all internal states."""
+    return DiagonalPotential(["0"] * num_states)

--- a/pytalises/propagator.py
+++ b/pytalises/propagator.py
@@ -1,13 +1,13 @@
-"""Module containing functions that help propagating the Wavefunction class."""
+"""Module containing functionality for wavefunction propagation."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from numba import jit, prange, set_num_threads
-from numpy.linalg import eigh
 import numexpr as ne
-import numpy as np
+
+from pytalises.options import PropagationOptions
+from pytalises.potentials import BasePotential, zero_potential
 
 if TYPE_CHECKING:
     from pytalises.wavefunction import Wavefunction
@@ -17,320 +17,220 @@ import pytalises.wavefunction
 
 def propagate(
     psi: Wavefunction,
-    potential: str | list[str],
-    num_time_steps: int,
-    delta_t: float,
-    **kwargs: Any,
+    potential: BasePotential,
+    steps: int,
+    dt: float,
+    *,
+    variables: dict[str, Any] | None = None,
+    options: PropagationOptions | None = None,
 ) -> None:
-    """
-    Propagates a Wavefunction object in time.
-
-    Function that propagates the wavefunction using a
-    Split-Step Fourier method [1].
-
-    Parameters
-    ----------
-    psi : Wavefunction
-        The Wavefunction object the Propagator class acts on
-    potential : string list of strings
-        This list contains the matrix elements of the potential term V
-        in string format. If the potential has nondiagonal elements
-        (see optional parameter diag) each elements represents
-        one matrix element of the lower triangular part of V.
-        For example a 3x3 potential with nondiagonal elements would be
-        of form potential=[H00, H10, H20, H11, H21, H22].
-        If the potential term is supposed to have only diagonal elements
-        (diag=True), the potential parameter for a 3x3 potential would
-        look like potential=[H00,H11,H22].
-    num_time_steps : int
-        Number of times the wavefunction is propagated by time delta_t
-        using the Split-Step Fourier method.
-    delta_t : float
-        Time increment the wavefunction is propagated in one time step.
-    variables : dict, optional
-        Dictionary containing values for variables you might have used
-        in potential
-    diag : bool , optional
-        If true, no numerical diagonalization has to be invoked in order
-        to calculate time-propagation as nondiagonal elements are omitted.
-        This makes the computation much faster. Default is False.
-    num_of_threads : int, optional
-        Number of threads uses for calculation. Default behaviour
-        is to use all threads available.
-    FFTWflags : tuple of strings
-        Options for FFTW planning [2]. Default is
-        ('FFTW_ESTIMATE', 'FFTW_DESTROY_INPUT',).
-
-    References
-    ----------
-    [1] https://en.wikipedia.org/wiki/Split-step_method
-    [2] http://www.fftw.org/fftw3_doc/Planner-Flags.html
-    """
-    U = Propagator(psi, potential, **kwargs)
-    U.kinetic_prop(delta_t / 2)
-    U.potential_prop(delta_t)
-    for _ in range(num_time_steps - 1):
-        U.kinetic_prop(delta_t)
-        U.potential_prop(delta_t)
-    U.kinetic_prop(delta_t / 2)
+    """Propagate a wavefunction in time using Strang splitting."""
+    U = Propagator(
+        psi,
+        potential,
+        variables=variables,
+        options=options,
+    )
+    U.kinetic_prop(dt / 2)
+    U.potential_prop(dt)
+    for _ in range(steps - 1):
+        U.kinetic_prop(dt)
+        U.potential_prop(dt)
+    U.kinetic_prop(dt / 2)
 
 
 def freely_propagate(
     psi: Wavefunction,
-    num_time_steps: int,
-    delta_t: float,
-    num_of_threads: int = 1,
-    FFTWflags: tuple[str, ...] = (
-        "FFTW_ESTIMATE",
-        "FFTW_DESTROY_INPUT",
-    ),
+    steps: int,
+    dt: float,
+    *,
+    options: PropagationOptions | None = None,
 ) -> None:
-    """
-    Propagates a Wavefunction object in time with V=0.
-
-    Function that can propagate the wavefunction if no potential
-    is present.
-
-    Parameters
-    ----------
-    psi : Wavefunction
-        The Wavefunction object the Propagator class acts on
-    num_time_steps : int
-        Number of times the wavefunction is propagated by time delta_t
-        using the Split-Step Fourier method.
-    delta_t : float
-        Time increment the wavefunction is propagated in one time step.
-    num_of_threads : int, optional
-        Number of threads uses for calculation. Default is 1.
-    FFTWflags : tuple of strings
-        Options for FFTW planning [1]. Default is
-        ('FFTW_ESTIMATE', 'FFTW_DESTROY_INPUT',).
-
-    References
-    ----------
-    [1] http://www.fftw.org/fftw3_doc/Planner-Flags.html
-    """
+    """Propagate a wavefunction in time with ``V = 0``."""
     U = Propagator(
         psi,
-        potential=["0"] * psi.num_int_dim,
-        diag=True,
-        num_of_threads=num_of_threads,
-        FFTWflags=FFTWflags,
+        potential=zero_potential(psi.num_int_dim),
+        variables={},
+        options=options,
     )
-    for _ in range(num_time_steps):
-        U.kinetic_prop(delta_t)
+    for _ in range(steps):
+        U.kinetic_prop(dt)
 
 
 class Propagator:
-    """
-    Class for propagating instances of the Wavefunction class.
-
-    Parameters
-    ----------
-    psi : Wavefunction
-        The Wavefunction object the Propagator class acts on
-    potential : list of strings
-        This list contains the matrix elements of the potential term V
-        in string format. If the potential has nondiagonal elements
-        (see optional parameter diag) each elements represents
-        one matrix element of the lower triangular part of V.
-        For example a 3x3 potential with nondiagonal elements would be
-        of form potential=[H00, H10, H20, H11, H21, H22].
-        If the potential term is supposed to have only diagonal elements
-        (diag=True), the potential argument for a 3x3 potential would
-        look like potential=[H00,H11,H22].
-    variables : dict, optional
-        Dictionary containing values for variables you might have used
-        in potential
-    diag : bool , optional
-        If true, no numerical diagonalization has to be invoked in order
-        to calculate time-propagation. Default is False.
-    num_of_threads : int, optional
-        Number of threads uses for calculation. Default is 1.
-    FFTWflags : tuple of strings
-        Options for FFTW planning [1]. Default is
-        ('FFTW_ESTIMATE', 'FFTW_DESTROY_INPUT',).
-
-    References
-    ----------
-    [1] http://www.fftw.org/fftw3_doc/Planner-Flags.html
-    """
+    """Class for propagating instances of :class:`pytalises.Wavefunction`."""
 
     def __init__(
         self,
-        psi,
-        potential,
-        variables={},
-        diag=False,
-        num_of_threads=1,
-        FFTWflags=(
-            "FFTW_ESTIMATE",
-            "FFTW_DESTROY_INPUT",
-        ),
+        psi: Wavefunction,
+        potential: BasePotential,
+        *,
+        variables: dict[str, Any] | None = None,
+        options: PropagationOptions | None = None,
     ):
-        """Initialize the propagator."""
+        """Initialize propagator."""
         self.psi = psi
-        self.v = self.Potential(potential, variables, diag)
+        self.options = options or PropagationOptions()
+
+        if self.options.backend not in ("auto", self.psi._backend.name):
+            raise ValueError(
+                "PropagationOptions.backend must match Wavefunction backend. "
+                f"Got options.backend='{self.options.backend}', "
+                f"wavefunction backend='{self.psi._backend.name}'."
+            )
+
+        self._backend = self.psi._backend
+        self._backend.set_num_threads(self.options.threads)
+
+        self.v = self.Potential.from_potential(
+            potential=potential,
+            variables=variables or {},
+            num_int_dim=psi.num_int_dim,
+        )
+
         assert isinstance(psi, pytalises.wavefunction.Wavefunction)
         assert self.v.num_int_dim == self.psi.num_int_dim
         assert self.psi._amp.shape[-1] == self.psi.num_int_dim
-        self.V_eval_array = np.zeros(
+
+        self.V_eval_array = self._backend.zeros(
             psi.number_of_grid_points + (psi.num_int_dim, psi.num_int_dim),
-            order="C",
             dtype="complex128",
         )
-        self.V_eval_eigval_array = np.zeros(
+        self.V_eval_eigval_array = self._backend.zeros(
             psi.number_of_grid_points + (psi.num_int_dim,),
-            order="C",
             dtype="complex128",
         )
-        self.num_of_threads = num_of_threads
-        set_num_threads(num_of_threads)
-        ne.set_num_threads(num_of_threads)
-        self.psi.construct_FFT(num_of_threads, FFTWflags)
-        # Chose method for calculating time propgation
-        # If potential is nondiagonal, additional
-        # numeric diangonalization will be performed
+
+        self.psi.construct_FFT(self.options.threads, self.options.fftw_flags)
+
         if self.v.diag is True:
             self.prop_method = self.diag_potential_prop
         else:
             self.prop_method = self.nondiag_potential_prop
-        # Check if potential is static and if that is the case
-        # precompute the potential grid V(x,y,z) to use it
-        # for all following calculations
+
         if self.v.static is True:
             if self.v.diag is True:
                 self.eval_diag_V()
-            if self.v.diag is False:
+            else:
                 self.eval_V()
-                get_eig(self.V_eval_array, self.V_eval_eigval_array)
+                self.V_eval_eigval_array, self.V_eval_array = self._backend.eigh(
+                    self.V_eval_array
+                )
 
-    def potential_prop(self, delta_t):
-        """
-        Wrap function that calculates exp(i*V(x,y,z)/hbar*delta_t)*Psi(x,y,z).
+    def potential_prop(self, dt: float) -> None:
+        """Apply potential propagator step."""
+        self.prop_method(dt)
 
-        This can be either nondiag_potential_prop or diag_potential_prop.
-        """
-        self.prop_method(delta_t)
-
-    def nondiag_potential_prop(self, delta_t):
-        """
-        Calculate exp(i*V/hbar*delta_t)*Psi using numerical diagonalization.
-
-        This method has to be used if the potential matrix has nondiagonal
-        elements.
-        """
+    def nondiag_potential_prop(self, dt: float) -> None:
+        """Apply potential step for non-diagonal potentials."""
         if self.v.static is False:
             self.eval_V()
-            get_eig(self.V_eval_array, self.V_eval_eigval_array)
-        np.einsum(
+            self.V_eval_eigval_array, self.V_eval_array = self._backend.eigh(
+                self.V_eval_array
+            )
+        self._backend.einsum(
             "xyzij,xyzj,xyzkj,xyzk->xyzi",
             self.V_eval_array,
-            ne.evaluate(
-                "exp(-1j*eigval*delta_t)",
-                local_dict={"eigval": self.V_eval_eigval_array, "delta_t": delta_t},
+            self._backend.evaluate(
+                "exp(-1j*eigval*dt)",
+                local_dict={"eigval": self.V_eval_eigval_array, "dt": dt},
             ),
-            np.conjugate(self.V_eval_array),
+            self._backend.conjugate(self.V_eval_array),
             self.psi._amp,
             out=self.psi._amp,
-            optimize="optimal",
-            order="C",
         )
 
-    def diag_potential_prop(self, delta_t):
-        """
-        Calculate exp(i*V/hbar*delta_t)*Psi by simple matrix multiplication.
-
-        This method is used if the potential matrix V is diagonal. This is
-        much faster than `nondiag_potential_prop` and should be used if
-        possible.
-        """
+    def diag_potential_prop(self, dt: float) -> None:
+        """Apply potential step for diagonal potentials."""
         if self.v.static is False:
             self.eval_diag_V()
-        np.einsum(
+        self._backend.einsum(
             "xyzii,xyzi->xyzi",
-            ne.evaluate(
-                "exp(-1j*V*delta_t)",
-                local_dict={"V": self.V_eval_array, "delta_t": delta_t},
+            self._backend.evaluate(
+                "exp(-1j*V*dt)",
+                local_dict={"V": self.V_eval_array, "dt": dt},
             ),
             self.psi._amp,
             out=self.psi._amp,
-            optimize="optimal",
-            order="C",
         )
 
-    def kinetic_prop(self, delta_t):
-        """
-        Perform time propagation in k-space.
-
-        Transforms the Wavefunction into k-space,
-        calculates exp(i*hbar/(2m)*k**2*delta_t)*Psi(kx,ky,kz)
-        and transforms it back into r-space.
-        """
+    def kinetic_prop(self, dt: float) -> None:
+        """Perform kinetic propagation step in reciprocal space."""
         self.psi.fft()
-        np.einsum(
+        self._backend.einsum(
             "xyz,xyzi->xyzi",
-            ne.evaluate(
-                "exp(-1j*alpha*delta_t*(kx**2+ky**2+kz**2))",
+            self._backend.evaluate(
+                "exp(-1j*alpha*dt*(kx**2+ky**2+kz**2))",
                 local_dict={
                     "kx": self.psi.kmesh[0],
                     "ky": self.psi.kmesh[1],
                     "kz": self.psi.kmesh[2],
                     "alpha": self.psi.alpha,
-                    "delta_t": delta_t,
+                    "dt": dt,
                 },
-                order="C",
             ),
             self.psi._amp,
             out=self.psi._amp,
-            optimize="optimal",
         )
         self.psi.ifft()
-        self.psi.t += delta_t
+        self.psi.t += dt
 
-    def eval_V(self):
-        """
-        Evalutes V on the whole spatial grid.
-
-        The result is saved in Propagator.V_eval_array.
-        """
+    def eval_V(self) -> None:
+        """Evaluate full potential matrix on the complete spatial grid."""
         k = 0
         for i in range(self.psi.num_int_dim):
             for j in range(i, self.psi.num_int_dim):
-                self.V_eval_array[:, :, :, j, i] = ne.evaluate(
+                self.V_eval_array[:, :, :, j, i] = self._backend.evaluate(
                     self.v.potential_strings[k],
                     local_dict={**self.v.variables, **self.psi.default_var_dict},
                     global_dict={"t": self.psi.t},
-                    order="C",
                 )
                 k += 1
 
-    def eval_diag_V(self):
-        """
-        Evalutes diagonal elements of V on the whole spatial grid.
-
-        The result is saved in Propagator.V_eval_array.
-        """
+    def eval_diag_V(self) -> None:
+        """Evaluate diagonal potential matrix elements."""
         for i in range(self.psi.num_int_dim):
-            self.V_eval_array[:, :, :, i, i] = ne.evaluate(
+            self.V_eval_array[:, :, :, i, i] = self._backend.evaluate(
                 self.v.potential_strings[i],
                 local_dict={**self.v.variables, **self.psi.default_var_dict},
                 global_dict={"t": self.psi.t},
-                order="C",
             )
 
     class Potential:
-        """Simple class for collecting information about the potential."""
+        """Simple container for potential metadata."""
 
-        def __init__(self, potential_string, variables={}, diag=False):
-            """Initialize Potential."""
-            if type(potential_string) is not list and type(potential_string) is str:
-                self.potential_strings = [potential_string]
-            else:
-                self.potential_strings = potential_string
+        @classmethod
+        def from_potential(
+            cls,
+            potential: BasePotential,
+            variables: dict[str, Any],
+            num_int_dim: int,
+        ) -> "Propagator.Potential":
+            if not isinstance(potential, BasePotential):
+                raise TypeError(
+                    "potential must be a structured potential object "
+                    "(e.g. DiagonalPotential or HermitianPotential)."
+                )
+            spec = potential.to_spec(num_states=num_int_dim)
+            return cls(
+                potential_string=list(spec.expressions),
+                variables=variables,
+                diag=spec.diag,
+            )
+
+        def __init__(
+            self,
+            potential_string: list[str],
+            variables: dict[str, Any] | None = None,
+            diag: bool = False,
+        ) -> None:
+            if variables is None:
+                variables = {}
+
+            self.potential_strings = potential_string
             self.num_v = len(self.potential_strings)
             self.variables = variables
-            # Check if potential is static in time
+
             for pot_string in self.potential_strings:
                 potential_nex = ne.NumExpr(pot_string)
                 try:
@@ -340,9 +240,7 @@ class Propagator:
                     self.static = True
                 if self.static is False:
                     break
-            # Check if potential is linear (independent of psi).
-            # If it depends on psi, it also depends on t and
-            # is therefore not static
+
             for i in range(len(self.potential_strings)):
                 for pot_string in self.potential_strings:
                     potential_nex = ne.NumExpr(pot_string)
@@ -357,42 +255,17 @@ class Propagator:
                 if self.linear is False:
                     self.static = False
                     break
-            # Check if number of matrix elements given matches
-            # the number diagonal or nondiagonal hermitian matrix
-            # elements. In the case of a diagonal matrix the number
-            # of matrix elements is equal to the number of internal
-            # states. If it is nondiagonal one gives the lower
-            # triangular part of V.
+
             self.diag = diag
             if diag is False:
-                self.num_int_dim = 1 / 2 * (np.sqrt(8 * self.num_v + 1) - 1)
+                self.num_int_dim = 1 / 2 * (self._sqrt(8 * self.num_v + 1) - 1)
                 assert (
                     self.num_int_dim.is_integer()
                 ), "Number of potential matrix elements incorrect"
                 self.num_int_dim = int(self.num_int_dim)
-            if diag is True:
+            else:
                 self.num_int_dim = len(self.potential_strings)
 
-
-@jit(nopython=True, parallel=True, nogil=True, fastmath=True)
-def get_eig(matrices, eigvals):
-    """
-    Calculate eigenvectors and eigenvalues of matrices in array.
-
-    JIT-compiled function that calculates the eigenvectors and
-    eigenvalues of input array M in parallel using numba.
-    The resulting eigenvectors are stored in the input matrix
-    and the eigenvalues in the array eigvals.
-
-    Parameters
-    ----------
-    M : 3d array of (NxN) arrays
-    eigvals : 3d array of 1d arrays with N elements
-    """
-    nX, nY, nZ = matrices.shape[:3]
-    for i in prange(nX):
-        for j in prange(nY):
-            for k in prange(nZ):
-                eigvals[i, j, k, :], matrices[i, j, k, :, :] = eigh(
-                    matrices[i, j, k, :, :]
-                )
+        @staticmethod
+        def _sqrt(x: float) -> float:
+            return float(x) ** 0.5

--- a/pytalises/wavefunction.py
+++ b/pytalises/wavefunction.py
@@ -6,162 +6,95 @@ from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
-import pyfftw
-import numexpr as ne
+
 import pytalises.propagator
+from pytalises.backends import get_backend
+from pytalises.backends.base import Backend
+from pytalises.grid import Grid
+from pytalises.options import PropagationOptions
+from pytalises.potentials import BasePotential
 
 
 class Wavefunction:
-    """
-    Class describing wave function.
+    """Wavefunction state for split-step propagation.
 
     Parameters
     ----------
-    psi : string list of strings
-        Each string describes the initial amplitude in r-space of
-        the wave function. The number of elements is the number
-        of internal degrees of freedom.
-        Additional variables that are used in psi can
-        be defined in the optional parameter variables.
-        Predefined variables are the spatial coordinates x,y,z
-        and time t.
-    number_of_grid_points : tuple of ints
-        Tuple that defines the number of grid points (nX,nY,nZ)
-        of the wave function
-    spatial_ext : list of tuples
-        The supplied values define the boundary positions of the grid
-        and thus define the actual coordinate system.
-    t0: float, optional
-        Internal time of wave function. Default is 0.0.
-    m : float, optional
-        Mass of particle described by the wavefunction.
-        Default is 1.054571817e-34 (numerically equal to hbar).
-    variables : dict
-        Dictionary of additionally used variables in the definition of
-        the wave function in psi.
-        Predefined variables are the spatial coordinates x,y,z
-        and time t.
-    normalize_const : float, optional
-        Normalizes the wave function such that the integral of |Psi|^2
-        over all internal and external degrees of freedom equals
-        `normalize_const`
-
-    Attributes
-    ----------
-    num_int_dim : int
-        The number of internal degrees of freedom
-    num_ex_dim : int
-        The number of external degrees of freedom
-    r : list of 1d arrays
-        The arrays are the evenly spaced spatial coordinates as defined
-        through definition of spatial_ext and number_of_grid_points
-    k : list of 1d arrays
-        The arrays are the evenly spaced inverse spatial coordinates as defined
-        through definition of spatial_ext and number_of_grid_points
-
-    Examples
-    --------
-    Wavefunction with two internal states
-    where the first state is gaussian
-    distributed in 1d r-space and the second
-    state is not occupied at all.
-
-    >>> from pytalises import Wavefunction
-    >>> psi = Wavefunction(["exp(-((x-x0)/a0)**2)", "0.0"],
-        (16,), [(-2,2),], variables={'a0':1/2, 'x0':0})
-    >>> print(psi.num_int_dim)
-    2
-    >>> print(psi.num_ext_dim)
-    1
-    >>> print(psi.amp)
-    [[1.12535175e-07+0.j 0.00000000e+00+0.j]
-    [6.03594712e-06+0.j 0.00000000e+00+0.j]
-    [1.83289361e-04+0.j 0.00000000e+00+0.j]
-    [3.15111160e-03+0.j 0.00000000e+00+0.j]
-    [3.06707930e-02+0.j 0.00000000e+00+0.j]
-    [1.69013315e-01+0.j 0.00000000e+00+0.j]
-    [5.27292424e-01+0.j 0.00000000e+00+0.j]
-    [9.31358402e-01+0.j 0.00000000e+00+0.j]
-    [9.31358402e-01+0.j 0.00000000e+00+0.j]
-    [5.27292424e-01+0.j 0.00000000e+00+0.j]
-    [1.69013315e-01+0.j 0.00000000e+00+0.j]
-    [3.06707930e-02+0.j 0.00000000e+00+0.j]
-    [3.15111160e-03+0.j 0.00000000e+00+0.j]
-    [1.83289361e-04+0.j 0.00000000e+00+0.j]
-    [6.03594712e-06+0.j 0.00000000e+00+0.j]
-    [1.12535175e-07+0.j 0.00000000e+00+0.j]]
-    >>> print(psi.r)
-    [array([-2.        , -1.73333333, -1.46666667, -1.2       , -0.93333333,
-       -0.66666667, -0.4       , -0.13333333,  0.13333333,  0.4       ,
-        0.66666667,  0.93333333,  1.2       ,  1.46666667,  1.73333333,
-        2.        ]), array([0.]), array([0.])]
+    initial
+        Initial amplitude expression(s). One string per internal state.
+    grid
+        Explicit spatial grid definition.
+    t0
+        Initial time.
+    m
+        Particle mass.
+    variables
+        Additional variables used in expressions.
+    normalize_const
+        If provided, normalize total population to this value.
+    backend
+        Backend name (``"auto"``, ``"numpy"``) or backend instance.
+    num_threads
+        Thread count for backend routines.
     """
 
     def __init__(
         self,
-        psi: str | list[str],
-        number_of_grid_points: tuple[int, ...] | int,
-        spatial_ext: list[tuple[float, float]] | tuple[float, float],
+        initial: str | list[str],
+        grid: Grid,
         t0: float = 0.0,
         m: float = 1.054571817e-34,
         variables: dict[str, Any] | None = None,
         normalize_const: float | None = None,
+        backend: str | Backend | None = "auto",
+        num_threads: int = 1,
     ) -> None:
-        """Initialize Wavefunction."""
         if variables is None:
             variables = {}
-        # It follows a series of checks if arguments are valid
-        assert_type_or_list_of_type(psi, str)
-        if type(psi) is not list and type(psi) is str:
-            psi = [psi]
-        if type(number_of_grid_points) is int:
-            number_of_grid_points = (number_of_grid_points,)
-        assert_type_or_list_of_type(number_of_grid_points, tuple)
-        if type(spatial_ext) is not list and type(spatial_ext) is tuple:
-            spatial_ext = [spatial_ext]
-        assert_type_or_list_of_type(spatial_ext, tuple)
-        assert type(t0) is float, "t0 is no float"
-        assert type(m) is float, "m is no float"
-        assert type(variables) is dict, "variables is no dict"
-        # Argument check passed.
-        # It follows generation of internal variables
-        # number of internal dims is number of provided strings to psi arg
-        self.num_int_dim = len(psi)
-        # number of external dims is number of ints in
-        # number_of_grid_points that is > 1
-        for _ in range(3 - len(number_of_grid_points)):
-            number_of_grid_points += (1,)
-        self.num_ext_dim = sum([1 for n in number_of_grid_points if n > 1])
-        self.nX, self.nY, self.nZ = number_of_grid_points
-        self.number_of_grid_points = number_of_grid_points
-        self.spatial_ext = spatial_ext
-        for _ in range(3 - len(self.spatial_ext)):
-            self.spatial_ext += ((0, 0),)
-        self.axes = tuple(np.where(np.array(number_of_grid_points) > 1, 1, 0))
-        # Generation of variables that describe the domain
-        # of the wave functionin position and momentum space
-        r = []
-        Delta_r = []
-        k = []
-        delta_k = []
-        for i, spatial_ext_tuple in enumerate(spatial_ext):
+        if isinstance(initial, str):
+            initial = [initial]
+        if not isinstance(grid, Grid):
+            raise TypeError("grid must be an instance of pytalises.Grid")
+        if not isinstance(t0, float):
+            raise TypeError("t0 must be float")
+        if not isinstance(m, float):
+            raise TypeError("m must be float")
+        if not isinstance(variables, dict):
+            raise TypeError("variables must be dict")
+
+        self._backend = get_backend(backend, num_threads=num_threads)
+
+        self.grid = grid
+        self.initial = list(initial)
+        self.num_int_dim = len(self.initial)
+
+        self.number_of_grid_points = self.grid.padded_shape
+        self.spatial_ext = list(self.grid.padded_extent)
+
+        self.num_ext_dim = self.grid.ndim
+        self.nX, self.nY, self.nZ = self.number_of_grid_points
+        self.axes = tuple(1 if n > 1 else 0 for n in self.number_of_grid_points)
+
+        r: list[NDArray[np.floating[Any]]] = []
+        Delta_r: list[float] = []
+        k: list[NDArray[np.floating[Any]] | float] = []
+        delta_k: list[float] = []
+
+        for i, spatial_ext_tuple in enumerate(self.spatial_ext):
             r_min = spatial_ext_tuple[0]
             r_max = spatial_ext_tuple[1]
-            r.append(np.linspace(r_min, r_max, num=number_of_grid_points[i]))
+            n = self.number_of_grid_points[i]
+            r_axis = self._backend.linspace(r_min, r_max, num=n)
+            r.append(r_axis)
             if self.axes[i] == 0:
                 Delta_r.append(np.nan)
                 delta_k.append(np.nan)
                 k.append(0.0)
             else:
-                Delta_r.append(r_max - r_min)
-                delta_k.append(2 * np.pi / (r_max - r_min))
-                k.append(
-                    np.fft.fftfreq(number_of_grid_points[i])
-                    * 2
-                    * np.pi
-                    * number_of_grid_points[i]
-                    / Delta_r[i]
-                )
+                drange = r_max - r_min
+                Delta_r.append(drange)
+                delta_k.append(2 * np.pi / drange)
+                k.append(self._backend.fftfreq(n) * 2 * np.pi * n / drange)
 
         self._r = r
         self.Delta_r = Delta_r
@@ -171,267 +104,192 @@ class Wavefunction:
         ]
         self.delta_k = delta_k
         self._k = k
-        self.rmesh = np.meshgrid(*r, indexing="ij")
-        self.kmesh = np.meshgrid(*k, indexing="ij")
-        self._amp = pyfftw.empty_aligned(
-            number_of_grid_points + (self.num_int_dim,), dtype="complex128", order="C"
+
+        self.rmesh = self._backend.meshgrid(*r, indexing="ij")
+        self.kmesh = self._backend.meshgrid(*k, indexing="ij")
+
+        self._amp = self._backend.empty_aligned(
+            self.number_of_grid_points + (self.num_int_dim,),
+            dtype="complex128",
         )
-        self.psi = psi
+
         self.t = t0
         self.m = m
-        # alpha is the diffusion factor in the kinetic operator
         self.alpha = 1.054571817e-34 / (2 * self.m)
+
         self.default_var_dict = {
             "alpha": self.alpha,
             "x": self.rmesh[0],
             "y": self.rmesh[1],
             "z": self.rmesh[2],
+            "t": self.t,
         }
-        # Define the variables that are used in the evaluation of the potentials
-        # during time propagation using the numexpr library
         for i in range(self.num_int_dim):
-            self.default_var_dict["psi" + str(i)] = self._amp[:, :, :, i]
+            self.default_var_dict[f"psi{i}"] = self._amp[:, :, :, i]
+
         self.variables = variables
         for i in range(self.num_int_dim):
-            self._amp[:, :, :, i] = ne.evaluate(
-                self.psi[i],
+            self._amp[:, :, :, i] = self._backend.evaluate(
+                self.initial[i],
                 local_dict={**self.default_var_dict, **self.variables},
-                order="C",
             )
+
         self.normalize_const = normalize_const
         if normalize_const is not None:
             self.normalize_to(normalize_const)
-        self.construct_FFT()
+
+        self.construct_FFT(num_threads=num_threads)
 
     def construct_FFT(
         self,
-        num_of_threads: int = 1,
+        num_threads: int = 1,
         FFTWflags: tuple[str, ...] = (
             "FFTW_ESTIMATE",
             "FFTW_DESTROY_INPUT",
         ),
     ) -> None:
-        """Construct pyfftw bindings."""
+        """Construct FFT bindings through backend plan interface."""
         axes = tuple(i for i in range(self.num_ext_dim))
-        pyfftw.config.NUM_THREADS = num_of_threads
-        self.fft = pyfftw.FFTW(
-            self._amp,
-            self._amp,
-            axes=axes,
-            direction="FFTW_FORWARD",
-            threads=num_of_threads,
-            flags=FFTWflags,
-        )
-        self.ifft = pyfftw.FFTW(
-            self._amp,
+        self._backend.set_num_threads(num_threads)
+        self._fft_plan = self._backend.create_fft_plan(
             self._amp,
             axes=axes,
-            direction="FFTW_BACKWARD",
-            threads=num_of_threads,
+            num_threads=num_threads,
             flags=FFTWflags,
         )
+        self.fft = self._fft_plan.forward
+        self.ifft = self._fft_plan.backward
+
+    def _active_axis_indices(self) -> list[int]:
+        return [i for i, active in enumerate(self.axes) if active]
+
+    def _volume_element(self) -> float:
+        elements = [self.delta_r[i] for i, active in enumerate(self.axes) if active]
+        if not elements:
+            return 1.0
+        return float(np.prod(elements))
 
     @property
-    def r(self) -> NDArray[np.floating[Any]] | list[NDArray[np.floating[Any]]]:
-        """(list of) array of the wave function position axes."""
-        if self.num_ext_dim == 1:
-            return self._r[self.axes.index(1)]
-        else:
-            return self._r
+    def r(self) -> tuple[NDArray[np.floating[Any]], ...]:
+        """Spatial coordinate arrays per active axis."""
+        return tuple(self._r[i] for i in self._active_axis_indices())
 
     @property
-    def k(self) -> NDArray[np.floating[Any]] | list[NDArray[np.floating[Any]]]:
-        """(list of) array of the wave function momentum axes."""
-        if self.num_ext_dim == 1:
-            return self._k[self.axes.index(1)]
-        else:
-            return self._k
+    def k(self) -> tuple[NDArray[np.floating[Any]], ...]:
+        """Reciprocal coordinate arrays per active axis."""
+        return tuple(self._k[i] for i in self._active_axis_indices())
 
     @property
     def amp(self) -> NDArray[np.complexfloating[Any, Any]]:
-        """Ndarray of the wave function amplitudes."""
-        return np.squeeze(self._amp)
+        """Wavefunction amplitudes in canonical public shape.
+
+        Shape is ``grid.shape + (num_internal_states,)``.
+        """
+        ext_dims = self.grid.ndim
+        index = (
+            (slice(None),) * ext_dims + (0,) * (3 - ext_dims) + (slice(None),)
+        )
+        return self._amp[index]
 
     def exp_pos(self, axis: int | None = None) -> NDArray[np.floating[Any]]:
-        """
-        Calculate the expected position on given axis.
-
-        Calculates the mean position of Psi on chosen axis.
-        Axes 0,1,2 correspond to x,y,z. The other two axes
-        are traced out. If no axis is given returns array
-        of mean position of all external degrees of freedom.
-        """
+        """Calculate expected position for one axis or all external axes."""
+        active_axes = self._active_axis_indices()
         if axis is None:
-            exp_pos = np.empty((self.num_ext_dim))
+            exp_pos = np.empty((self.num_ext_dim,))
             for i in range(self.num_ext_dim):
                 exp_pos[i] = self.exp_pos(i)
-        else:
-            axes_to_trace = [0, 1, 2]
-            axis = axes_to_trace.pop(axis)
-            psi_sq_amp = np.power(np.abs(self._amp), 2)
-            traced_out_psi = np.sum(psi_sq_amp, axis=tuple(axes_to_trace))
-            exp_pos = np.einsum("ri,r->", traced_out_psi, self._r[axis])
-            exp_pos *= np.prod(self.delta_r, where=np.where(self.axes, True, False))
+            return exp_pos
+
+        if not (0 <= axis < self.num_ext_dim):
+            raise ValueError(f"axis must be in [0, {self.num_ext_dim - 1}]")
+
+        phys_axis = active_axes[axis]
+        axes_to_trace = [0, 1, 2]
+        axes_to_trace.pop(phys_axis)
+        psi_sq_amp = self._backend.power(self._backend.abs(self._amp), 2)
+        traced_out_psi = self._backend.sum(psi_sq_amp, axis=tuple(axes_to_trace))
+        exp_pos = self._backend.einsum("ri,r->", traced_out_psi, self._r[phys_axis])
+        exp_pos *= self._volume_element()
         return exp_pos
 
     def var_pos(self, axis: int | None = None) -> NDArray[np.floating[Any]]:
-        """
-        Calculate the variance on given axis.
-
-        Calculates the variance in position of Psi on chosen axis.
-        Axes 0,1,2 correspond to x,y,z. The other two axes
-        are traced out. If no axis is given returns array
-        of variance position of all external degrees of freedom.
-        """
+        """Calculate position variance for one axis or all external axes."""
+        active_axes = self._active_axis_indices()
         if axis is None:
-            var_pos = np.empty((self.num_ext_dim))
+            var_pos = np.empty((self.num_ext_dim,))
             for i in range(self.num_ext_dim):
                 var_pos[i] = self.var_pos(i)
-        else:
-            axes_to_trace = [0, 1, 2]
-            i = axis
-            axis = axes_to_trace.pop(axis)
-            psi_sq_amp = np.power(np.abs(self._amp), 2)
-            traced_out_psi = np.sum(psi_sq_amp, axis=tuple(axes_to_trace))
-            var_pos = np.einsum(
-                "ri,r->", traced_out_psi, (self._r[axis] - self.exp_pos(i)) ** 2
-            )
-            var_pos *= np.prod(self.delta_r, where=np.where(self.axes, True, False))
+            return var_pos
+
+        if not (0 <= axis < self.num_ext_dim):
+            raise ValueError(f"axis must be in [0, {self.num_ext_dim - 1}]")
+
+        phys_axis = active_axes[axis]
+        axes_to_trace = [0, 1, 2]
+        axes_to_trace.pop(phys_axis)
+        psi_sq_amp = self._backend.power(self._backend.abs(self._amp), 2)
+        traced_out_psi = self._backend.sum(psi_sq_amp, axis=tuple(axes_to_trace))
+        var_pos = self._backend.einsum(
+            "ri,r->",
+            traced_out_psi,
+            (self._r[phys_axis] - self.exp_pos(axis)) ** 2,
+        )
+        var_pos *= self._volume_element()
         return var_pos
 
     def normalize_to(self, n_const: float) -> None:
-        """
-        Normalize the wave function.
-
-        Normalizes the wave function such that the integral
-        of |Psi|^2 over all internal and external states
-        equals n_const
-        """
-        # Calculate |Psi|^2 over all internal and external states
-        s = np.einsum("xyzi,xyzi->", self._amp, np.conjugate(self._amp))
-        # Mulitply with product of infinitesimal volumes dx*dy*dz
-        # while ignoring nonextisten dimensions
-        s *= np.prod(self.delta_r, where=np.where(self.axes, True, False))
-        self._amp *= np.sqrt(n_const / s)
+        """Normalize total wavefunction occupation to ``n_const``."""
+        s = self._backend.einsum("xyzi,xyzi->", self._amp, self._backend.conjugate(self._amp))
+        s *= self._volume_element()
+        self._amp *= self._backend.sqrt(n_const / s)
 
     def state_occupation(
         self, nth_state: int | None = None
     ) -> NDArray[np.floating[Any]]:
-        """
-        Return occupation number of nth internal state.
-
-        Evaluates the spatial integral over |Psi|^2 for
-        the nth internal state. If none is given a vector
-        of the occupation number of all internal states
-        is returned.
-        """
+        """Return occupation number of one internal state or all states."""
         if nth_state is None:
-            state_occupation = np.empty((self.num_int_dim,))
+            occ = np.empty((self.num_int_dim,))
             for i in range(self.num_int_dim):
-                state_occupation[i] = self.state_occupation(i)
-        else:
-            state_occupation = np.sum(
-                np.abs(self._amp[:, :, :, nth_state]) ** 2
-            ) * np.prod(self.delta_r, where=np.where(self.axes, True, False))
-        return state_occupation
+                occ[i] = self.state_occupation(i)
+            return occ
+
+        if not (0 <= nth_state < self.num_int_dim):
+            raise ValueError(f"nth_state must be in [0, {self.num_int_dim - 1}]")
+
+        return (
+            self._backend.sum(self._backend.abs(self._amp[:, :, :, nth_state]) ** 2)
+            * self._volume_element()
+        )
 
     def freely_propagate(
         self,
-        num_time_steps: int,
-        delta_t: float,
-        num_of_threads: int = 1,
-        FFTWflags: tuple[str, ...] = (
-            "FFTW_ESTIMATE",
-            "FFTW_DESTROY_INPUT",
-        ),
+        steps: int,
+        dt: float,
+        options: PropagationOptions | None = None,
     ) -> None:
-        """
-        Propagates the Wavefunction object in time with V=0.
-
-        Function that can propagate the wavefunction if no potential
-        is present.
-
-        Parameters
-        ----------
-        num_time_steps : int
-            Number of times the wavefunction is propagated by time delta_t
-            using the Split-Step Fourier method.
-        delta_t : float
-            Time increment the wavefunction is propagated in one time step.
-        num_of_threads : int, optional
-            Number of threads uses for calculation. Default is 1.
-        FFTWflags : tuple of strings
-            Options for FFTW planning [1]. Default is
-            ('FFTW_ESTIMATE', 'FFTW_DESTROY_INPUT',).
-
-        References
-        ----------
-        [1] http://www.fftw.org/fftw3_doc/Planner-Flags.html
-        """
+        """Propagate the wavefunction in time with ``V = 0``."""
         pytalises.propagator.freely_propagate(
-            self, num_time_steps, delta_t, num_of_threads, FFTWflags
+            self,
+            steps,
+            dt,
+            options=options,
         )
 
     def propagate(
         self,
-        potential: str | list[str],
-        num_time_steps: int,
-        delta_t: float,
-        **kwargs: Any,
+        potential: BasePotential,
+        steps: int,
+        dt: float,
+        *,
+        variables: dict[str, Any] | None = None,
+        options: PropagationOptions | None = None,
     ) -> None:
-        """
-        Propagates the Wavefunction object in time.
-
-        Function that propagates the wavefunction using a
-        Split-Step Fourier method [1].
-
-        Parameters
-        ----------
-        potential : string list of strings
-            This list contains the matrix elements of the potential term V
-            in string format. If the potential has nondiagonal elements
-            (see optional parameter diag) each elements represents
-            one matrix element of the lower triangular part of V.
-            For example a 3x3 potential with nondiagonal elements would be
-            of form potential=[H00, H10, H20, H11, H21, H22].
-            If the potential term is supposed to have only diagonal elements
-            (diag=True), the potential parameter for a 3x3 potential would
-            look like potential=[H00,H11,H22].
-        num_time_steps : int
-            Number of times the wavefunction is propagated by time delta_t
-            using the Split-Step Fourier method.
-        delta_t : float
-            Time increment the wavefunction is propagated in one time step.
-        variables : dict, optional
-            Dictionary containing values for variables you might have used
-            in potential
-        diag : bool , optional
-            If true, no numerical diagonalization has to be invoked in order
-            to calculate time-propagation as nondiagonal elements are omitted.
-            This makes the computation much faster. Default is False.
-        num_of_threads : int, optional
-            Number of threads uses for calculation. Default behaviour
-            is to use all threads available.
-        FFTWflags : tuple of strings
-            Options for FFTW planning [2]. Default is
-            ('FFTW_ESTIMATE', 'FFTW_DESTROY_INPUT',).
-
-        References
-        ----------
-        [1] https://en.wikipedia.org/wiki/Split-step_method
-        [2] http://www.fftw.org/fftw3_doc/Planner-Flags.html
-        """
+        """Propagate the wavefunction in time with a structured potential."""
         pytalises.propagator.propagate(
-            self, potential, num_time_steps, delta_t, **kwargs
+            self,
+            potential,
+            steps,
+            dt,
+            variables=variables,
+            options=options,
         )
-
-
-def assert_type_or_list_of_type(argument, wished_type):
-    assert (
-        type(argument) is wished_type or type(argument) is list
-    ), "{} is not {} or list of {}.".format(argument, wished_type, wished_type)
-    if type(argument) is list:
-        for argument_element in argument:
-            assert (
-                type(argument_element) is wished_type
-            ), "{} is not {} or list of {}.".format(argument, wished_type, wished_type)

--- a/pytalises/wavefunction.py
+++ b/pytalises/wavefunction.py
@@ -71,9 +71,9 @@ class Wavefunction:
         self.number_of_grid_points = self.grid.padded_shape
         self.spatial_ext = list(self.grid.padded_extent)
 
-        self.num_ext_dim = self.grid.ndim
-        self.nX, self.nY, self.nZ = self.number_of_grid_points
         self.axes = tuple(1 if n > 1 else 0 for n in self.number_of_grid_points)
+        self.num_ext_dim = int(sum(self.axes))
+        self.nX, self.nY, self.nZ = self.number_of_grid_points
 
         r: list[NDArray[np.floating[Any]]] = []
         Delta_r: list[float] = []
@@ -122,7 +122,6 @@ class Wavefunction:
             "x": self.rmesh[0],
             "y": self.rmesh[1],
             "z": self.rmesh[2],
-            "t": self.t,
         }
         for i in range(self.num_int_dim):
             self.default_var_dict[f"psi{i}"] = self._amp[:, :, :, i]
@@ -132,6 +131,7 @@ class Wavefunction:
             self._amp[:, :, :, i] = self._backend.evaluate(
                 self.initial[i],
                 local_dict={**self.default_var_dict, **self.variables},
+                global_dict={"t": self.t},
             )
 
         self.normalize_const = normalize_const
@@ -149,7 +149,7 @@ class Wavefunction:
         ),
     ) -> None:
         """Construct FFT bindings through backend plan interface."""
-        axes = tuple(i for i in range(self.num_ext_dim))
+        axes = tuple(i for i, active in enumerate(self.axes) if active)
         self._backend.set_num_threads(num_threads)
         self._fft_plan = self._backend.create_fft_plan(
             self._amp,

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1,0 +1,13 @@
+import pytalises as pt
+
+
+def test_default_backend_is_numpy():
+    backend = pt.get_backend()
+    assert backend.name == "numpy"
+
+
+def test_wavefunction_uses_backend_instance():
+    backend = pt.get_backend("numpy", num_threads=2)
+    grid = pt.Grid(shape=(32,), extent=((-1, 1),))
+    psi = pt.Wavefunction("exp(-x**2)", grid=grid, backend=backend)
+    assert psi._backend is backend

--- a/tests/legacy_test.py
+++ b/tests/legacy_test.py
@@ -1,0 +1,31 @@
+import warnings
+
+import numpy as np
+import pytalises as pt
+
+
+def test_legacy_wavefunction_and_propagation():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        psi = pt.legacy.Wavefunction("exp(-x**2)", (64,), (-2, 2), normalize_const=1.0)
+        psi.freely_propagate(num_time_steps=1, delta_t=0.01)
+        psi.propagate("x**2", num_time_steps=1, delta_t=0.01, diag=True)
+
+    assert any(issubclass(item.category, DeprecationWarning) for item in w)
+    np.testing.assert_almost_equal(np.sum(psi.state_occupation()), 1.0, decimal=5)
+
+
+def test_legacy_module_level_wrappers():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        psi = pt.legacy.Wavefunction(
+            ["exp(-x**2)", "0"], (64,), (-2, 2), normalize_const=1.0
+        )
+        pt.legacy.propagate(
+            psi,
+            ["0", "sin(t)", "0"],
+            num_time_steps=2,
+            delta_t=0.01,
+            diag=False,
+        )
+    np.testing.assert_almost_equal(np.sum(psi.state_occupation()), 1.0, decimal=5)

--- a/tests/physics_test.py
+++ b/tests/physics_test.py
@@ -1,28 +1,32 @@
-import pytalises as pt
-import numpy as np
 import itertools
+
+import numpy as np
+import pytalises as pt
+
+
+def g1(n=128, a=-1.0, b=1.0):
+    return pt.Grid(shape=(n,), extent=((a, b),))
+
+
+def g2(nx=128, ny=128, a=-7.5, b=7.5):
+    return pt.Grid(shape=(nx, ny), extent=((a, b), (a, b)))
 
 
 def test_rabi_oscillations():
-    """
-    Tests if the popoulation in a driven two-level system
-    undergoes Rabi oscillations. It is compared with analytical
-    results.
-    """
+    """Population in a driven two-level system follows Rabi oscillations."""
     f_Rabi_selection = [0.5, 1, 10]
     f_Delta_selection = [0, 0.5, 1]
 
     cases = itertools.product(f_Rabi_selection, f_Delta_selection)
 
-    for case in cases:
-        f_Rabi, f_Delta = case
-        f_g_Rabi = np.sqrt(f_Rabi ** 2 + f_Delta ** 2)  # generalized Rabi frequency
-        time = 1 / f_g_Rabi
+    for f_Rabi, f_Delta in cases:
+        f_g_Rabi = np.sqrt(f_Rabi**2 + f_Delta**2)
+        period = 1 / f_g_Rabi
 
-        psi = pt.Wavefunction(["exp(-x**2)", "0"], (128,), (-1, 1), normalize_const=1.0)
+        psi = pt.Wavefunction(["exp(-x**2)", "0"], g1(128, -1, 1), normalize_const=1.0)
         U = pt.Propagator(
             psi,
-            ["0", "Omega/2", "Delta"],
+            pt.HermitianPotential.from_lower_triangular(["0", "Omega/2", "Delta"]),
             variables={"Omega": 2 * np.pi * f_Rabi, "Delta": 2 * np.pi * f_Delta},
         )
 
@@ -33,24 +37,21 @@ def test_rabi_oscillations():
                 np.array(
                     [
                         1
-                        - f_Rabi ** 2
-                        / f_g_Rabi ** 2
+                        - f_Rabi**2
+                        / f_g_Rabi**2
                         * np.sin(2 * np.pi * f_g_Rabi * psi.t / 2) ** 2,
-                        f_Rabi ** 2
-                        / f_g_Rabi ** 2
+                        f_Rabi**2
+                        / f_g_Rabi**2
                         * np.sin(2 * np.pi * f_g_Rabi * psi.t / 2) ** 2,
                     ]
                 ),
             )
-            U.potential_prop(delta_t=time / n_steps)
-            U.kinetic_prop(delta_t=time / n_steps)
+            U.potential_prop(dt=period / n_steps)
+            U.kinetic_prop(dt=period / n_steps)
 
 
 def test_free_propagation_of_gaussian_wave_packet():
-    """
-    Tests if a gaussian wave packet disperses and moves
-    as predicted by the Schrödinger equation.
-    """
+    """Gaussian wave packet disperses/moves as predicted by Schrödinger equation."""
     sigma0_select = [0.5, 1, 5]
     x0_select = [-3.432, 0, 10]
     k0_select = [-5, 0, 6.2341]
@@ -59,13 +60,10 @@ def test_free_propagation_of_gaussian_wave_packet():
 
     cases = itertools.product(sigma0_select, x0_select, k0_select, m_select)
 
-    for case in cases:
-        print(case)
-        sigma0, x0, k0, m = case
+    for sigma0, x0, k0, m in cases:
         psi = pt.Wavefunction(
             ["exp(-((x-x0)/(2*sigma0))**2)*exp(1j*k0*x)"],
-            (32768,),
-            (-200, 200),
+            pt.Grid(shape=(32768,), extent=((-200, 200),)),
             normalize_const=1.0,
             variables={"sigma0": sigma0, "x0": x0, "k0": k0},
             m=m,
@@ -73,22 +71,20 @@ def test_free_propagation_of_gaussian_wave_packet():
 
         for _ in range(10):
             np.testing.assert_almost_equal(
-                psi.var_pos(),
-                sigma0 ** 2 + (hbar ** 2 * psi.t ** 2) / (4 * m ** 2 * sigma0 ** 2),
+                psi.var_pos()[0],
+                sigma0**2 + (hbar**2 * psi.t**2) / (4 * m**2 * sigma0**2),
                 decimal=2,
             )
             np.testing.assert_almost_equal(
-                psi.exp_pos(), x0 + hbar / m * k0 * psi.t, decimal=2
+                psi.exp_pos()[0],
+                x0 + hbar / m * k0 * psi.t,
+                decimal=2,
             )
-            psi.freely_propagate(num_time_steps=1, delta_t=1)
+            psi.freely_propagate(steps=1, dt=1)
 
 
 def test_two_dimensional_harmonic_oscillator():
-    """
-    Tests if the center of mass of a gaussian wave packet in
-    an harmonic oscillator moves as expected.
-    """
-
+    """Center of mass motion in 2D harmonic oscillator follows analytic form."""
     x0_select = [0, 0.5]
     y0_select = [0.5, 1.5]
     omega_x_select = [2 * np.pi * 0.8]
@@ -96,24 +92,21 @@ def test_two_dimensional_harmonic_oscillator():
 
     cases = itertools.product(x0_select, y0_select, omega_x_select, omega_y_select)
 
-    for case in cases:
-        x0, y0, omega_x, omega_y = case
+    for x0, y0, omega_x, omega_y in cases:
         psi = pt.Wavefunction(
             ["exp(-((x-x0)/(2*1))**2)*exp(-((y-y0)/(2*1))**2)"],
-            (128, 128),
-            [(-7.5, 7.5), (-7.5, 7.5)],
+            g2(128, 128, -7.5, 7.5),
             normalize_const=1.0,
             variables={"x0": x0, "y0": y0},
         )
-        time = 2 * np.pi / omega_x
+        period = 2 * np.pi / omega_x
         n_steps = 10
         for _ in range(n_steps):
             psi.propagate(
-                "1/2*omega_x**2*x**2 + 1/2*omega_y**2*y**2",
+                potential=pt.DiagonalPotential("1/2*omega_x**2*x**2 + 1/2*omega_y**2*y**2"),
                 variables={"omega_x": omega_x, "omega_y": omega_y},
-                diag=True,
-                num_time_steps=10,
-                delta_t=1 / 10 * time / n_steps,
+                steps=10,
+                dt=0.1 * period / n_steps,
             )
             np.testing.assert_almost_equal(
                 psi.exp_pos(),

--- a/tests/propagator_test.py
+++ b/tests/propagator_test.py
@@ -82,6 +82,19 @@ def test_time_dependent_nondiagonal_potential():
     np.testing.assert_almost_equal(np.sum(psi.state_occupation()), 1.0, decimal=5)
 
 
+def test_time_variable_is_dynamic_in_potential_evaluation():
+    psi = pt.Wavefunction("1.0", g1(64, -1, 1), t0=0.0)
+    amp_before = psi.amp.copy()
+    dt = 0.1
+    psi.propagate(potential=pt.DiagonalPotential("t"), steps=1, dt=dt)
+
+    # With Strang splitting, potential is evaluated after the first half-step
+    # kinetic propagation -> at t = dt/2.
+    expected_phase = np.exp(-1j * (dt / 2) * dt)
+    ratio = psi.amp[0, 0] / amp_before[0, 0]
+    np.testing.assert_allclose(ratio / expected_phase, 1.0, atol=1e-10)
+
+
 def test_multidimensional_wavefunction_properties():
     psi_2d = pt.Wavefunction(
         "exp(-x**2 - y**2)",

--- a/tests/propagator_test.py
+++ b/tests/propagator_test.py
@@ -1,38 +1,46 @@
-import pytalises as pt
 import numpy as np
+import pytalises as pt
+
+
+def g1(n=64, a=-2.0, b=2.0):
+    return pt.Grid(shape=(n,), extent=((a, b),))
 
 
 def test_potential_static_and_linear_detection():
-    static_potential = pt.propagator.Propagator.Potential(["x", "y"], diag=True)
-    assert static_potential.static is True
-    assert static_potential.linear is True
+    static_potential = pt.DiagonalPotential(["x", "y"])
+    p = pt.propagator.Propagator.Potential.from_potential(static_potential, {}, 2)
+    assert p.static is True
+    assert p.linear is True
 
-    time_dependent = pt.propagator.Propagator.Potential(["t"], diag=True)
-    assert time_dependent.static is False
+    time_dependent = pt.DiagonalPotential(["t"])
+    p = pt.propagator.Propagator.Potential.from_potential(time_dependent, {}, 1)
+    assert p.static is False
 
-    nonlinear = pt.propagator.Propagator.Potential(["psi0"], diag=True)
-    assert nonlinear.static is False
-    assert nonlinear.linear is False
+    nonlinear = pt.DiagonalPotential(["psi0"])
+    p = pt.propagator.Propagator.Potential.from_potential(nonlinear, {}, 1)
+    assert p.static is False
+    assert p.linear is False
 
 
 def test_potential_internal_dimension_resolution():
-    two_state_diag = pt.propagator.Propagator.Potential(["x", "2*x"], diag=True)
-    assert two_state_diag.num_int_dim == 2
+    two_state_diag = pt.DiagonalPotential(["x", "2*x"])
+    p_diag = pt.propagator.Propagator.Potential.from_potential(two_state_diag, {}, 2)
+    assert p_diag.num_int_dim == 2
 
-    two_state_nondiag = pt.propagator.Propagator.Potential(["x", "0", "y"], diag=False)
-    assert two_state_nondiag.num_int_dim == 2
+    two_state_nondiag = pt.HermitianPotential.from_lower_triangular(["x", "0", "y"])
+    p_non = pt.propagator.Propagator.Potential.from_potential(two_state_nondiag, {}, 2)
+    assert p_non.num_int_dim == 2
 
 
 def test_wavefunction_normalization_and_moments():
-    psi = pt.Wavefunction("exp(-x**2)", (64,), (-2, 2), normalize_const=1.0)
+    psi = pt.Wavefunction("exp(-x**2)", g1(64, -2, 2), normalize_const=1.0)
 
-    # Test r and k properties for 1D wavefunction
     r = psi.r
     k = psi.k
-    assert isinstance(r, np.ndarray)
-    assert isinstance(k, np.ndarray)
-    assert r.shape == (64,)
-    assert k.shape == (64,)
+    assert isinstance(r, tuple)
+    assert isinstance(k, tuple)
+    assert r[0].shape == (64,)
+    assert k[0].shape == (64,)
 
     exp_all = psi.exp_pos()
     exp_axis = psi.exp_pos(axis=0)
@@ -47,65 +55,48 @@ def test_wavefunction_normalization_and_moments():
 
 
 def test_time_dependent_diagonal_potential():
-    """Test propagation with a time-dependent diagonal potential."""
     psi = pt.Wavefunction(
         ["exp(-x**2)", "0"],
-        (64,),
-        (-3, 3),
+        g1(64, -3, 3),
         normalize_const=1.0,
     )
-    # Time-dependent potential V = t * x^2 (harmonic with time-varying strength)
     psi.propagate(
-        potential=["t*x**2", "t*x**2"],
-        num_time_steps=5,
-        delta_t=0.01,
-        diag=True,
+        potential=pt.DiagonalPotential(["t*x**2", "t*x**2"]),
+        steps=5,
+        dt=0.01,
     )
-    # Check normalization is preserved
     np.testing.assert_almost_equal(np.sum(psi.state_occupation()), 1.0, decimal=5)
 
 
 def test_time_dependent_nondiagonal_potential():
-    """Test propagation with a time-dependent nondiagonal potential."""
     psi = pt.Wavefunction(
         ["exp(-x**2)", "0"],
-        (32,),
-        (-2, 2),
+        g1(32, -2, 2),
         normalize_const=1.0,
     )
-    # Time-dependent coupling: V01 = sin(t)
-    # Lower triangular: [V00, V10, V11]
     psi.propagate(
-        potential=["0", "sin(t)", "0"],
-        num_time_steps=3,
-        delta_t=0.01,
-        diag=False,
+        potential=pt.HermitianPotential.from_lower_triangular(["0", "sin(t)", "0"]),
+        steps=3,
+        dt=0.01,
     )
-    # Normalization should be preserved
     np.testing.assert_almost_equal(np.sum(psi.state_occupation()), 1.0, decimal=5)
 
 
 def test_multidimensional_wavefunction_properties():
-    """Test r, k properties for multi-dimensional wavefunctions."""
-    # 2D wavefunction
     psi_2d = pt.Wavefunction(
         "exp(-x**2 - y**2)",
-        (32, 32),
-        [(-2, 2), (-2, 2)],
+        pt.Grid(shape=(32, 32), extent=((-2, 2), (-2, 2))),
         normalize_const=1.0,
     )
-    # r and k should return lists for multi-dim
     r = psi_2d.r
     k = psi_2d.k
-    assert isinstance(r, list)
-    assert isinstance(k, list)
-    assert len(r) == 3  # x, y, z (z is trivial)
-    assert len(k) == 3
-    # Verify the arrays have the right shapes
+    assert isinstance(r, tuple)
+    assert isinstance(k, tuple)
+    assert len(r) == 2
+    assert len(k) == 2
     assert r[0].shape == (32,)
     assert r[1].shape == (32,)
     assert k[0].shape == (32,)
     assert k[1].shape == (32,)
 
-    # amp should be squeezed
-    assert psi_2d.amp.shape == (32, 32)  # squeezed from (32, 32, 1, 1)
+    assert psi_2d.amp.shape == (32, 32, 1)

--- a/tests/wavefunction_test.py
+++ b/tests/wavefunction_test.py
@@ -76,6 +76,24 @@ def test_wavefunction_dimensional_cases_and_quick_propagation():
     )
 
 
+def test_singleton_axes_are_treated_as_inactive_dimensions():
+    psi = pt.Wavefunction(
+        "exp(-y**2)",
+        pt.Grid(shape=(1, 64), extent=((0.0, 0.0), (-2.0, 2.0))),
+        normalize_const=1.0,
+    )
+
+    assert psi.num_ext_dim == 1
+    assert len(psi.r) == 1
+    assert psi.r[0].shape == (64,)
+
+    exp_all = psi.exp_pos()
+    np.testing.assert_allclose(exp_all, np.array([psi.exp_pos(axis=0)]))
+
+    # Ensure FFT plans are created on active axes only.
+    psi.freely_propagate(steps=1, dt=0.01)
+
+
 def test_state_occupation_conservation_quick():
     wf = pt.Wavefunction(["exp(-x**2)", "0"], g1(64, -3, 3), normalize_const=1.0)
     V = pt.HermitianPotential.from_lower_triangular(["0", "sin(t)", "0"])

--- a/tests/wavefunction_test.py
+++ b/tests/wavefunction_test.py
@@ -1,142 +1,83 @@
-import pytalises as pt
-import numpy as np
 import itertools
 
+import numpy as np
+import pytalises as pt
 
-def test_Wavenfunction_init():
-    # 1D Arguments not as list
-    psi = pt.Wavefunction("exp(-x**2)", (128,), (-1, 1), normalize_const=1.0)
-    np.testing.assert_almost_equal(psi.state_occupation(), 1.0)
-    # 1D Arguments as list
-    pt.Wavefunction(["exp(-x**2)"], (128,), [(-1, 1)])
-    pt.Wavefunction(["exp(-x**2)", "cos(x)"], (128,), [(-1, 1)])
-    pt.Wavefunction(["exp(-x**2)", "b"], (128,), [(-1, 1)], variables={"b": 1})
-    # 2D Arguments not as list
-    pt.Wavefunction("exp(-x**2-y**2)", (128, 128), [(-1, 1), (-1, 1)])
-    # 2D Arguments as list
-    pt.Wavefunction(["exp(-x**2-y**2)"], (128, 128), [(-1, 1), (-1, 1)])
-    psi = pt.Wavefunction(
-        ["exp(-x**2-y**2)", "c*x**2+y**2"],
-        (128, 128),
-        [(-1, 1), (-1, 1)],
-        variables={"c": 1},
-        normalize_const=666,
-    )
-    np.testing.assert_almost_equal(np.sum(psi.state_occupation()), 666)
-    # 3D Arguments not as list
-    pt.Wavefunction(
-        "exp(-x**2-y**2-z**2/d)+d",
-        (128, 128, 128),
-        [(-1, 1), (-1, 1), (-1, 1)],
-        variables={"d": 1},
-    )
-    # 3D Arguments as list
-    pt.Wavefunction(
-        ["exp(-x**2-y**2-z**2/d)+d"],
-        (128, 128, 128),
-        [(-1, 1), (-1, 1), (-1, 1)],
-        variables={"d": 1},
-    )
 
-    # 1D + one internal state
-    psi = [
+def g1(n=64, a=-2.0, b=2.0):
+    return pt.Grid(shape=(n,), extent=((a, b),))
+
+
+def g2(nx=32, ny=32, a=-2.0, b=2.0):
+    return pt.Grid(shape=(nx, ny), extent=((a, b), (a, b)))
+
+
+def g3(n=16, a=-2.0, b=2.0):
+    return pt.Grid(shape=(n, n, n), extent=((a, b), (a, b), (a, b)))
+
+
+def test_wavefunction_init_and_basic_properties():
+    psi = pt.Wavefunction("exp(-x**2)", g1(128, -1, 1), normalize_const=1.0)
+    np.testing.assert_almost_equal(np.sum(psi.state_occupation()), 1.0)
+
+    # multiple internal states, variable usage
+    psi2 = pt.Wavefunction(
+        ["exp(-x**2)", "b*cos(x)"],
+        g1(64, -1, 1),
+        variables={"b": 1.0},
+        normalize_const=2.0,
+    )
+    np.testing.assert_almost_equal(np.sum(psi2.state_occupation()), 2.0)
+
+    assert len(psi.r) == 1
+    assert len(psi.k) == 1
+    assert psi.amp.shape == (128, 1)
+
+
+def test_wavefunction_dimensional_cases_and_quick_propagation():
+    # 1D
+    psi_1d_cases = [
         "exp(-x**2)",
         ["exp(-x**2)"],
+        ["exp(-x**2)", "0"],
     ]
-    number_of_grid_points = [
-        16,
-        (16,),
-        (
-            16,
-            1,
-        ),
-        (16, 1, 1),
+    V_diag_1d = [
+        pt.DiagonalPotential("0"),
+        pt.DiagonalPotential("sin(x)"),
+        pt.DiagonalPotential("2*x**2"),
     ]
-    spatial_ext = [
-        (-2, 2),
-        [
-            (-2, 2),
-        ],
-    ]
-    variables = [
-        {"a0": 0, "x0": 1},
-    ]
-    V = ["0", ["0"], "sin(x)", "2*x**2"]
-    all_valid_cases = itertools.product(
-        psi, number_of_grid_points, spatial_ext, variables, V
-    )
-    for case in all_valid_cases:
-        psi = pt.Wavefunction(
-            psi=case[0],
-            number_of_grid_points=case[1],
-            spatial_ext=case[2],
-            variables=case[3],
-        )
-        psi.freely_propagate(num_time_steps=1, delta_t=1)
-        psi.propagate(potential=case[4], num_time_steps=1, delta_t=1)
 
-    # 2D + one internal state
-    psi = [
-        "exp(-x**2)*y",
-        ["exp(-x/a0**2)*exp(-y**2)"],
-    ]
-    number_of_grid_points = [
-        (
-            16,
-            16,
-        ),
-        (16, 16, 1),
-    ]
-    spatial_ext = [
-        [(-2, 2), (-5, 5)],
-    ]
-    variables = [
-        {"a0": 0, "x0": 1},
-    ]
-    V = ["0", ["0"], "sin(x*y)", "2*x**2*y"]
-    all_valid_cases = itertools.product(
-        psi, number_of_grid_points, spatial_ext, variables, V
-    )
-    for case in all_valid_cases:
-        psi = pt.Wavefunction(
-            psi=case[0],
-            number_of_grid_points=case[1],
-            spatial_ext=case[2],
-            variables=case[3],
-        )
-        psi.freely_propagate(num_time_steps=1, delta_t=1)
-        psi.propagate(potential=case[4], num_time_steps=1, delta_t=1)
+    for initial in psi_1d_cases:
+        wf = pt.Wavefunction(initial, g1(32), normalize_const=1.0)
+        wf.freely_propagate(steps=1, dt=1.0)
 
-    # 3D + two internal state
-    psi = [
-        ["exp(-x/a0**2)*exp(-y**2)*exp(-z**2)", "0"],
-    ]
-    number_of_grid_points = [
-        (16, 16, 16),
-    ]
-    spatial_ext = [
-        [(-2, 2), (-5, 5), (-2, 2)],
-    ]
-    variables = [
-        {"a0": 0, "x0": 1},
-    ]
-    V = [
-        ["0", "sin(x*y)", "z"],
-        ["x", "sin(x*y)"],
-    ]
-    all_valid_cases = itertools.product(
-        psi, number_of_grid_points, spatial_ext, variables, V
-    )
-    for case in all_valid_cases:
-        if len(case[4]) == 2:
-            diag = True
+        if wf.num_int_dim == 1:
+            for V in V_diag_1d:
+                wf.propagate(potential=V, steps=1, dt=1.0)
         else:
-            diag = False
-        psi = pt.Wavefunction(
-            psi=case[0],
-            number_of_grid_points=case[1],
-            spatial_ext=case[2],
-            variables=case[3],
-        )
-        psi.freely_propagate(num_time_steps=1, delta_t=1)
-        psi.propagate(potential=case[4], num_time_steps=1, delta_t=1, diag=diag)
+            V = pt.HermitianPotential.from_lower_triangular(["0", "sin(x)", "0"])
+            wf.propagate(potential=V, steps=1, dt=1.0)
+
+    # 2D
+    psi_2d = pt.Wavefunction("exp(-x**2-y**2)", g2(24, 24), normalize_const=1.0)
+    psi_2d.propagate(
+        potential=pt.DiagonalPotential("x**2 + y**2"),
+        steps=1,
+        dt=0.1,
+    )
+    assert psi_2d.amp.shape == (24, 24, 1)
+
+    # 3D + two states, non-diagonal potential
+    psi_3d = pt.Wavefunction(["exp(-x**2-y**2-z**2)", "0"], g3(12), normalize_const=1.0)
+    psi_3d.propagate(
+        potential=pt.HermitianPotential.from_lower_triangular(["0", "x", "sin(y)"]),
+        steps=1,
+        dt=0.05,
+    )
+
+
+def test_state_occupation_conservation_quick():
+    wf = pt.Wavefunction(["exp(-x**2)", "0"], g1(64, -3, 3), normalize_const=1.0)
+    V = pt.HermitianPotential.from_lower_triangular(["0", "sin(t)", "0"])
+    wf.propagate(V, steps=3, dt=0.01)
+    np.testing.assert_almost_equal(np.sum(wf.state_occupation()), 1.0, decimal=5)


### PR DESCRIPTION
## Summary
- introduce the v2 public API surface (Grid, structured potentials, PropagationOptions)
- add a backend abstraction scaffold and wire the default NumPy backend
- keep a temporary pytalises.legacy adapter that emits deprecation warnings for v1-style entry points
- add migration docs in docs/source/v2_migration.rst and update API docs index
- refresh tooling/CI as part of phase-1 cleanup

## Migration notes
- replace number_of_grid_points + spatial_ext with Grid(shape=..., extent=...)
- replace num_time_steps/delta_t with steps/dt
- replace diag=True/False string-list potentials with DiagonalPotential / HermitianPotential
- use pytalises.legacy as a temporary bridge if you still need v1 calling style

## Scope
This PR is the core/API track only. CuPy support is split into a follow-up PR.

## Validation
- python -m pytest tests/ -q
- result: 16 passed

## Privacy
Internal planning markdown files were intentionally excluded from this PR.
